### PR TITLE
fix: prevent georeferenceVerificationStatus to raw_geo_validation_status mapping being overwritten

### DIFF
--- a/src/main/scala/au/org/ala/biocache/index/IndexDAO.scala
+++ b/src/main/scala/au/org/ala/biocache/index/IndexDAO.scala
@@ -1337,7 +1337,7 @@ trait IndexDAO {
       tup =>
         tup._1 match {
           case "phenology" => ("lifeStage", "life_stage", 4, RAW)
-          case "georeferenceVerificationStatus" => ("georeferenceVerificationStatus", "georeference_verification_status", -1, RAW_AND_PARSED)
+          case "georeferenceVerificationStatus" if(tup._2 == "georeference_verification_status") => ("georeferenceVerificationStatus", "georeference_verification_status", -1, RAW_AND_PARSED)
           case "identificationVerificationStatus" => ("identificationVerificationStatus", "identification_verification_status", -1, RAW_AND_PARSED)
           case "verbatimDepth" => ("verbatimDepth", "raw_depth", -1, RAW)
           case _ => tup


### PR DESCRIPTION
Header attributes list contains two mappings for `georeferenceVerificationStatus`, one for the raw value and one for the processed valued. 

The case statement was overriding both and so indexing was trying to write to georeference_verification_status twice.

Added a guard to the case expression

This may also need patching in NBNSolrDao > getOccIndexModel